### PR TITLE
fix basic auth; fix listing lists; error handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ cache:
 php:
   - 5.3
   - 5.6
+  - 7.0
 
 env:
   global:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2015-2017 Daniel Bachhuber
+Copyright (c) 2017 Dale Phurrough
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/composer.json
+++ b/composer.json
@@ -1,37 +1,41 @@
 {
-    "name": "wp-cli/restful",
-    "description": "Unlock the potential of the WP REST API at the command line.",
-	"type": "wp-cli-package",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Daniel Bachhuber",
-            "email": "daniel@handbuilt.co"
-        }
-    ],
-    "minimum-stability": "dev",
-    "autoload": {
-        "files": [ "wp-rest-cli.php" ]
-    },
-    "require": {},
-    "require-dev": {
-        "behat/behat": "~2.5"
-    },
-    "extras": {
-        "commands": [
-            "rest user list",
-            "rest user generate"
-        ],
-        "readme": {
-            "package_description": {
-                "post": "bin/readme-stubs/package-description-post.md"
-            },
-            "using": {
-                "body": "bin/readme-stubs/using.md"
-            },
-            "installing": {
-                "body": "bin/readme-stubs/installing.md"
-            }
-        }
+  "name": "wp-cli/restful",
+  "description": "Unlock the potential of the WP REST API at the command line.",
+  "type": "wp-cli-package",
+  "license": "MIT",
+  "authors": [{
+      "name": "Daniel Bachhuber",
+      "email": "daniel@handbuilt.co"
+    }, {
+      "name": "Dale Phurrough",
+      "email": "dale@hidale.com",
+      "homepage": "https://hidale.com",
+      "role": "Developer"
     }
+  ],
+  "minimum-stability": "dev",
+  "autoload": {
+    "files": ["wp-rest-cli.php"]
+  },
+  "require": {},
+  "require-dev": {
+    "behat/behat": "~2.5"
+  },
+  "extras": {
+    "commands": [
+      "rest user list",
+      "rest user generate"
+    ],
+    "readme": {
+      "package_description": {
+        "post": "bin/readme-stubs/package-description-post.md"
+      },
+      "using": {
+        "body": "bin/readme-stubs/using.md"
+      },
+      "installing": {
+        "body": "bin/readme-stubs/installing.md"
+      }
+    }
+  }
 }

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -160,6 +160,9 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	 * @param array $parameters context parameters (set them up through behat.yml)
 	 */
 	public function __construct( array $parameters ) {
+		if ( getenv( 'RESTFUL_TEST_DBHOST' ) ) {
+			self::$db_settings['dbhost'] = getenv( 'RESTFUL_TEST_DBHOST' );
+		}
 		$this->drop_db();
 		$this->set_cache_dir();
 		$this->variables['CORE_CONFIG_SETTINGS'] = Utils\assoc_args_to_str( self::$db_settings );

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -160,8 +160,8 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	 * @param array $parameters context parameters (set them up through behat.yml)
 	 */
 	public function __construct( array $parameters ) {
-		if ( getenv( 'RESTFUL_TEST_DBHOST' ) ) {
-			self::$db_settings['dbhost'] = getenv( 'RESTFUL_TEST_DBHOST' );
+		if ( getenv( 'WP_CLI_TEST_DBHOST' ) ) {
+			self::$db_settings['dbhost'] = getenv( 'WP_CLI_TEST_DBHOST' );
 		}
 		$this->drop_db();
 		$this->set_cache_dir();

--- a/features/comment.feature
+++ b/features/comment.feature
@@ -2,7 +2,8 @@ Feature: Manage WordPress comments through the REST API
 
   Background:
     Given a WP install
-    And I run `wp plugin install rest-api --activate`
+    When I run `wp core version`
+	Then STDOUT should be a version string >= 4.7
 
   Scenario: Help for all available commands
     When I run `wp rest comment --help`
@@ -59,13 +60,13 @@ Feature: Manage WordPress comments through the REST API
     When I run `wp rest comment list --format=headers`
     Then STDOUT should be JSON containing:
       """
-      {"X-WP-TotalPages":1}
+      {"x-wp-totalpages":1}
       """
 
     When I run `wp rest comment list --format=envelope`
     Then STDOUT should be JSON containing:
       """
-      {"headers":{"X-WP-TotalPages":1}}
+      {"headers":{"x-wp-totalpages":1}}
       """
 
   Scenario: List comments with different contexts

--- a/features/comment.feature
+++ b/features/comment.feature
@@ -133,8 +133,9 @@ Feature: Manage WordPress comments through the REST API
     When I try `wp rest comment update 1 --content="Hello World"`
     Then STDERR should contain:
       """
-      Error: Sorry, you are not allowed to edit this comment.
+      Error: Sorry, you are not allowed to edit this comment. HTTP code: 401
       """
+    Then the return code should be 145
 
     When I run `wp rest comment update 1 --content="Hello World" --user=1`
     Then STDOUT should contain:
@@ -152,8 +153,9 @@ Feature: Manage WordPress comments through the REST API
     When I try `wp rest comment delete 1`
     Then STDERR should contain:
       """
-      Error: Sorry, you are not allowed to delete this comment.
+      Error: Sorry, you are not allowed to delete this comment. HTTP code: 401
       """
+    Then the return code should be 145
 
     When I run `wp rest comment delete 1 --user=1`
     Then STDOUT should contain:

--- a/features/comment.feature
+++ b/features/comment.feature
@@ -133,7 +133,7 @@ Feature: Manage WordPress comments through the REST API
     When I try `wp rest comment update 1 --content="Hello World"`
     Then STDERR should contain:
       """
-      Error: Sorry, you can not edit this comment
+      Error: Sorry, you are not allowed to edit this comment.
       """
 
     When I run `wp rest comment update 1 --content="Hello World" --user=1`
@@ -152,7 +152,7 @@ Feature: Manage WordPress comments through the REST API
     When I try `wp rest comment delete 1`
     Then STDERR should contain:
       """
-      Error: Sorry, you can not delete this comment
+      Error: Sorry, you are not allowed to delete this comment.
       """
 
     When I run `wp rest comment delete 1 --user=1`

--- a/features/load-rest.feature
+++ b/features/load-rest.feature
@@ -2,7 +2,8 @@ Feature: Manage WordPress through endpoints locally
 
   Background:
     Given a WP install
-    And I run `wp plugin install rest-api --activate`
+	When I run `wp core version`
+	Then STDOUT should be a version string >= 4.7
 
   Scenario: REST endpoints should load as WP-CLI commands
     When I run `wp help rest`

--- a/features/post.feature
+++ b/features/post.feature
@@ -2,7 +2,8 @@ Feature: Manage WordPress posts through the REST API
 
   Background:
     Given a WP install
-    And I run `wp plugin install rest-api --activate`
+    When I run `wp core version`
+    Then STDOUT should be a version string >= 4.7
 
   Scenario: Get the value of an individual post field
     When I run `wp rest post get 1 --field=title`
@@ -17,10 +18,16 @@ Feature: Manage WordPress posts through the REST API
     And save STDOUT as {POST_ID}
 
     When I run `wp rest post update {POST_ID} --user=admin --title="Test Post Two" --porcelain`
-    Then STDOUT should be a number
+    Then STDOUT should be:
+      """
+      {POST_ID}
+      """
 
     When I run `wp rest post delete {POST_ID} --user=admin --force=true --porcelain`
-    Then STDOUT should be a number
+    Then STDOUT should be:
+      """
+      {POST_ID}
+      """
 
   Scenario: Generate posts
     When I run `wp rest post list --format=count`
@@ -40,9 +47,99 @@ Feature: Manage WordPress posts through the REST API
 
     When I run `wp rest post generate --user=admin --status=publish --count=9 --title="Test Post"`
     Then STDOUT should be empty
+	Then STDERR should be empty
 
     When I run `wp rest post list --format=count`
     Then STDOUT should be:
       """
       20
+      """
+
+Scenario: Manipulate post revisions
+    When I run `wp rest post create --user=admin --title="Test Post for Revisions" --content="This is test content." --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {POST_ID}
+
+    When I run `wp rest post update {POST_ID} --user=admin --status=publish --porcelain`
+    Then STDOUT should be:
+      """
+      {POST_ID}
+      """
+
+    When I run `wp rest post update {POST_ID} --user=admin --content="This is my first revision of test content." --porcelain`
+    Then STDOUT should be:
+      """
+      {POST_ID}
+      """
+
+    When I run `wp rest post update {POST_ID} --user=admin --content="This is my second revision of test content." --porcelain`
+    Then STDOUT should be a number
+    Then STDOUT should be:
+      """
+      {POST_ID}
+      """
+
+    When I run `wp rest post-revision list {POST_ID} --user=admin --fields=parent,content`
+    Then STDOUT should be a table containing rows:
+    | parent    | content                                                              |
+    | {POST_ID} | {"rendered":"<p>This is my second revision of test content.<\/p>\n"} |
+    | {POST_ID} | {"rendered":"<p>This is my first revision of test content.<\/p>\n"}  |
+
+    When I run `wp rest post list --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """
+
+    When I run `wp rest post-revision list {POST_ID} --user=admin --format=count`
+    Then STDOUT should be:
+      """
+      3
+      """
+
+    When I run `wp rest post-revision list {POST_ID} --user=admin --format=ids`
+    Then save STDOUT '(\d+)' as {REV_ID}
+
+    When I run `wp rest post-revision get {POST_ID} {REV_ID} --user=admin`
+    Then STDOUT should be a table containing rows:
+    | Field  | Value     |
+    | author | 1         |
+    | id     | {REV_ID}  |
+    | parent | {POST_ID} |
+
+    When I run `wp rest post-revision delete {POST_ID} {REV_ID} --user=admin --force=true --porcelain`
+    Then STDOUT should be:
+      """
+      {REV_ID}
+      """
+
+    When I try `wp rest post-revision delete {POST_ID} {REV_ID} --user=admin --force=true --porcelain`
+    Then the return code should be 148
+    Then STDERR should contain:
+      """
+      Error: Invalid revision ID. HTTP code: 404
+      """
+
+    When I run `wp rest post-revision list {POST_ID} --user=admin --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """
+
+    When I run `wp rest post list --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """
+
+    When I run `wp rest post delete {POST_ID} --user=admin --force=true --porcelain`
+    Then STDOUT should be:
+      """
+      {POST_ID}
+      """
+
+    When I run `wp rest post list --format=count`
+    Then STDOUT should be:
+      """
+      1
       """

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -102,7 +102,7 @@ $steps->Given( '/^download:$/',
 	}
 );
 
-$steps->Given( '/^save (STDOUT|STDERR) ([\'].+[^\'])?as \{(\w+)\}$/',
+$steps->Given( '/^save (STDOUT|STDERR) ([\'].+[^\'])?\s?as \{(\w+)\}$/',
 	function ( $world, $stream, $output_filter, $key ) {
 
 		$stream = strtolower( $stream );

--- a/features/steps/then.php
+++ b/features/steps/then.php
@@ -145,6 +145,16 @@ $steps->Then( '/^(STDOUT|STDERR) should not be empty$/',
 	}
 );
 
+$steps->Then( '/^(STDOUT|STDERR) should be a version string (<|<=|>|>=|==|=|!=|<>) ([+\w\.-]+)$/',
+	function ( $world, $stream, $operator, $goal_ver ) {
+
+		$stream = strtolower( $stream );
+		if ( false === version_compare( trim( $world->result->$stream, "\n" ), $goal_ver, $operator ) ) {
+			throw new Exception( $world->result );
+		}
+	}
+);
+
 $steps->Then( '/^the (.+) (file|directory) should (exist|not exist|be:|contain:|not contain:)$/',
 	function ( $world, $path, $type, $action, $expected = null ) {
 		$path = $world->replace_variables( $path );

--- a/inc/RestCommand.php
+++ b/inc/RestCommand.php
@@ -153,9 +153,9 @@ class RestCommand {
 	}
 
 	/**
-	 * Delete an existing item.
+	 * Purge all (aka delete all) items in a collection
 	 *
-	 * @subcommand delete
+	 * @subcommand purgeall
 	 */
 	public function purgeall_items( $args, $assoc_args ) {
 		list( $status, $body ) = $this->do_request( 'DELETE', $this->get_filled_route( $args ), $assoc_args );

--- a/inc/RestCommand.php
+++ b/inc/RestCommand.php
@@ -146,6 +146,28 @@ class RestCommand {
 	}
 
 	/**
+	 * Delete an existing item.
+	 *
+	 * @subcommand delete
+	 */
+	public function purgeall_items( $args, $assoc_args ) {
+		list( $status, $body ) = $this->do_request( 'DELETE', $this->get_filled_route( $args ), $assoc_args );
+		if ( Utils\get_flag_value( $assoc_args, 'porcelain' ) ) {
+			if ( $status < 400 ) {
+				WP_CLI::halt( 0 );
+			} else {
+				WP_CLI::halt( $status );
+			}
+		} else {
+			if ( $status < 400 ) {
+				WP_CLI::success( "Purged all {$this->name}." );
+			} else {
+				WP_CLI::error( "Could not complete request. HTTP code: {$status}", $status );
+			}
+		}
+	}
+
+	/**
 	 * Get a single item.
 	 *
 	 * @subcommand get
@@ -559,7 +581,10 @@ EOT;
 	 * Fill the route based on provided $args
 	 */
 	private function get_filled_route( $args ) {
-		return rtrim( $this->get_base_route(), '/' ) . '/' . $args[0];
+		if ( 1 < count($args) ) {
+			WP_CLI::error( 'wp-cli rest does not support command routes with more than one argument' );
+		}
+		return rtrim( $this->get_base_route(), '/' ) . '/' . ( isset( $args[0] ) ? $args[0] : '' );
 	}
 
 	/**

--- a/inc/RestCommand.php
+++ b/inc/RestCommand.php
@@ -496,6 +496,10 @@ EOT;
 				WP_CLI::debug( "REST command executed {$query_count} queries in {$query_total_time} seconds{$slow_query_message}", 'rest' );
 			}
 			if ( $error = $response->as_error() ) {
+				$error_status = $error->get_error_data();
+				if (is_array( $error_status ) && array_key_exists( 'status', $error_status ) ) {
+					WP_CLI::error( $error->get_error_message() . " HTTP code: {$error_status['status']}", $error_status['status'] );
+				}
 				WP_CLI::error( $error->get_error_message() );
 			}
 			return array( $response->get_status(), $response->get_data(), $response->get_headers() );
@@ -512,11 +516,11 @@ EOT;
 			$body = json_decode( $response->body, true );
 			if ( $response->status_code >= 400 ) {
 				if ( ! empty( $body['message'] ) ) {
-					WP_CLI::error( $body['message'] );
+					WP_CLI::error( $body['message'], $response->status_code );
 				} else {
 					switch( $response->status_code ) {
 						case 404:
-							WP_CLI::error( "No {$this->name} found." );
+							WP_CLI::error( "No {$this->name} found.", $response->status_code );
 							break;
 						default:
 							WP_CLI::error( "Could not complete request. HTTP code: {$response->status_code}", $response->status_code );
@@ -754,5 +758,4 @@ EOT;
 		}
 		return $item;
 	}
-
 }

--- a/inc/RestCommand.php
+++ b/inc/RestCommand.php
@@ -158,6 +158,7 @@ class RestCommand {
 	 */
 	private static function same_array_array_keys( $toparray ) {
 		list( $key_first_child, $val_first_child ) = each( $toparray );
+		if ( !is_array( $val_first_child ) ) return false;
 		$num_keys_first_child = count($val_first_child);
 		while ( list( $key_sibling, $val_sibling ) = each( $toparray ) ) {
 			if ( count($val_sibling) !== $num_keys_first_child ) return false;
@@ -207,7 +208,7 @@ class RestCommand {
 			$formatter = $this->get_formatter( $assoc_args );
 			if ( isset( $items[0] ) )
 				$formatter->display_items( $items );
-			if ( self::same_array_array_keys( $items ) )
+			elseif ( self::same_array_array_keys( $items ) )
 				$formatter->display_items( $items );
 			else
 				$formatter->display_item( $items );

--- a/inc/RestCommand.php
+++ b/inc/RestCommand.php
@@ -254,7 +254,9 @@ class RestCommand {
 				'api_url'     => $this->api_url,
 			) );
 		} else {
-			if ( empty( $items ) ) return;
+			if ( empty( $items ) ) {
+				return;
+			}
 			$formatter = $this->get_formatter( $assoc_args );
 			if ( isset( $items[0] ) )
 				$formatter->display_items( $items );

--- a/inc/RestCommand.php
+++ b/inc/RestCommand.php
@@ -207,7 +207,7 @@ class RestCommand {
 	 */
 	private static function same_array_array_keys( $toparray ) {
 		list( $key_first_child, $val_first_child ) = each( $toparray );
-		if ( !is_array( $val_first_child ) ) return false;
+		if ( ! is_array( $val_first_child ) ) return false;
 		$num_keys_first_child = count($val_first_child);
 		while ( list( $key_sibling, $val_sibling ) = each( $toparray ) ) {
 			if ( count($val_sibling) !== $num_keys_first_child ) return false;

--- a/inc/RestCommand.php
+++ b/inc/RestCommand.php
@@ -561,7 +561,7 @@ EOT;
 			}
 
 			// normalize headers and return result
-			$norm_headers = [];
+			$norm_headers = array();
 			foreach ( $response->headers->getAll() as $key => $value ) {
 				$norm_headers[ $key ] = $response->headers->flatten( $value );
 			}

--- a/inc/RestCommand.php
+++ b/inc/RestCommand.php
@@ -151,6 +151,22 @@ class RestCommand {
 	}
 
 	/**
+	 * Compare the keys of the array of arrays for same size and keys
+	 *
+	 * @param array $toparray
+	 * @return boolean
+	 */
+	private static function same_array_array_keys( $toparray ) {
+		list( $key_first_child, $val_first_child ) = each( $toparray );
+		$num_keys_first_child = count($val_first_child);
+		while ( list( $key_sibling, $val_sibling ) = each( $toparray ) ) {
+			if ( count($val_sibling) !== $num_keys_first_child ) return false;
+			if ( array_diff_key( $val_first_child, $val_sibling ) ) return false;
+		}
+		return true;
+	}
+
+	/**
 	 * List all items.
 	 *
 	 * @subcommand list
@@ -189,7 +205,12 @@ class RestCommand {
 			) );
 		} else {
 			$formatter = $this->get_formatter( $assoc_args );
-			$formatter->display_items( $items );
+			if ( isset( $items[0] ) )
+				$formatter->display_items( $items );
+			if ( self::same_array_array_keys( $items ) )
+				$formatter->display_items( $items );
+			else
+				$formatter->display_item( $items );
 		}
 	}
 
@@ -440,7 +461,7 @@ EOT;
 					}
 				}
 			}
-			return array( $response->status_code, json_decode( $response->body, true ), $response->headers->getAll() );
+			return array( $response->status_code, $body, $response->headers->getAll() );
 		}
 		WP_CLI::error( 'Invalid scope for REST command.' );
 	}

--- a/inc/RestCommand.php
+++ b/inc/RestCommand.php
@@ -165,6 +165,7 @@ class RestCommand {
 				'api_url'     => $this->api_url,
 			) );
 		} else {
+			if ( empty( $body ) ) return;
 			$formatter = $this->get_formatter( $assoc_args );
 			$formatter->display_item( $body );
 		}
@@ -225,6 +226,7 @@ class RestCommand {
 				'api_url'     => $this->api_url,
 			) );
 		} else {
+			if ( empty( $items ) ) return;
 			$formatter = $this->get_formatter( $assoc_args );
 			if ( isset( $items[0] ) )
 				$formatter->display_items( $items );

--- a/inc/RestCommand.php
+++ b/inc/RestCommand.php
@@ -14,7 +14,7 @@ class RestCommand {
 	private $name;
 	private $route;
 	private $schema;
-	private $named_path_vars = [ [] ];
+	private $named_path_vars = array( array() );
 	private $default_context = '';
 	private $output_nesting_level = 0;
 

--- a/inc/RestCommand.php
+++ b/inc/RestCommand.php
@@ -97,9 +97,9 @@ class RestCommand {
 			if ( $status < 400 ) {
 				if ( Utils\get_flag_value( $assoc_args, 'porcelain' ) ) {
 					WP_CLI::line( $body['id'] );
-				} else if ( 'progress' === $format ) {
+				} elseif ( 'progress' === $format ) {
 					$notify->tick();
-				} else if ( 'ids' === $format ) {
+				} elseif ( 'ids' === $format ) {
 					echo $body['id'];
 					if ( $i < $count - 1 ) {
 						echo ' ';
@@ -181,9 +181,9 @@ class RestCommand {
 
 		if ( 'headers' === $assoc_args['format'] ) {
 			echo json_encode( $headers );
-		} else if ( 'body' === $assoc_args['format'] ) {
+		} elseif ( 'body' === $assoc_args['format'] ) {
 			echo json_encode( $body );
-		} else if ( 'envelope' === $assoc_args['format'] ) {
+		} elseif ( 'envelope' === $assoc_args['format'] ) {
 			echo json_encode( array(
 				'body'        => $body,
 				'headers'     => $headers,
@@ -242,11 +242,11 @@ class RestCommand {
 
 		if ( ! empty( $assoc_args['format'] ) && 'count' === $assoc_args['format'] ) {
 			echo (int) $headers['X-WP-Total'];
-		} else if ( 'headers' === $assoc_args['format'] ) {
+		} elseif ( 'headers' === $assoc_args['format'] ) {
 			echo json_encode( $headers );
-		} else if ( 'body' === $assoc_args['format'] ) {
+		} elseif ( 'body' === $assoc_args['format'] ) {
 			echo json_encode( $body );
-		} else if ( 'envelope' === $assoc_args['format'] ) {
+		} elseif ( 'envelope' === $assoc_args['format'] ) {
 			echo json_encode( array(
 				'body'        => $body,
 				'headers'     => $headers,
@@ -335,7 +335,7 @@ class RestCommand {
 						}
 					}
 				}
-			} else if ( ! empty( $to_body ) ) {
+			} elseif ( ! empty( $to_body ) ) {
 				$to_item = array_shift( $to_body );
 			}
 
@@ -491,7 +491,7 @@ class RestCommand {
 EOT;
 						$slow_query_message .= PHP_EOL;
 					}
-				} else if ( 'rest' !== WP_CLI::get_config( 'debug' ) ) {
+				} elseif ( 'rest' !== WP_CLI::get_config( 'debug' ) ) {
 					$slow_query_message = '. Use --debug=rest to see all queries.';
 				}
 				$query_total_time = round( $query_total_time, 6 );
@@ -505,7 +505,7 @@ EOT;
 				WP_CLI::error( $error->get_error_message() );
 			}
 			return array( $response->get_status(), $response->get_data(), $response->get_headers() );
-		} else if ( 'http' === $this->scope ) {
+		} elseif ( 'http' === $this->scope ) {
 			$headers = array();
 			if ( ! empty( $this->auth ) && 'basic' === $this->auth['type'] ) {
 				$headers['Authorization'] = 'Basic ' . base64_encode( $this->auth['username'] . ':' . $this->auth['password'] );
@@ -627,7 +627,7 @@ EOT;
 
 					$this->recursively_show_difference( $value, $new_current );
 
-				} else if ( is_string( $value ) ) {
+				} elseif ( is_string( $value ) ) {
 
 					$pre = $key . ': ';
 
@@ -636,7 +636,7 @@ EOT;
 						$this->remove_line( $pre . $current[ $key ] );
 						$this->add_line( $pre . $value );
 
-					} else if ( ! isset( $current[ $key ] ) ) {
+					} elseif ( ! isset( $current[ $key ] ) ) {
 
 						$this->add_line( $pre . $value );
 
@@ -646,7 +646,7 @@ EOT;
 
 			}
 
-		} else if ( is_array( $dictated ) ) {
+		} elseif ( is_array( $dictated ) ) {
 
 			foreach( $dictated as $value ) {
 
@@ -657,7 +657,7 @@ EOT;
 
 			}
 
-		} else if ( is_string( $value ) ) {
+		} elseif ( is_string( $value ) ) {
 
 			$pre = $key . ': ';
 
@@ -666,7 +666,7 @@ EOT;
 				$this->remove_line( $pre . $current[ $key ] );
 				$this->add_line( $pre . $value );
 
-			} else if ( ! isset( $current[ $key ] ) ) {
+			} elseif ( ! isset( $current[ $key ] ) ) {
 
 				$this->add_line( $pre . $value );
 
@@ -708,7 +708,7 @@ EOT;
 		if ( 'add' == $change ) {
 			$color = '%G';
 			$label = '+ ';
-		} else if ( 'remove' == $change ) {
+		} elseif ( 'remove' == $change ) {
 			$color = '%R';
 			$label = '- ';
 		} else {

--- a/inc/Runner.php
+++ b/inc/Runner.php
@@ -109,8 +109,10 @@ class Runner {
 	 * @return array|false
 	 */
 	private static function get_api_index( $api_url, $auth ) {
+		// this method to add a query is weak; may cause problems, e.g. duplicate keynames
 		$query_char = false !== strpos( $api_url, '?' ) ? '&' : '?';
 		$api_url .= $query_char . 'context=help';
+
 		$headers = array();
 		if ( ! empty( $auth ) && 'basic' === $auth['type'] ) {
 			$headers['Authorization'] = 'Basic ' . base64_encode( $auth['username'] . ':' . $auth['password'] );
@@ -153,9 +155,6 @@ class Runner {
 				WP_CLI::debug( "Route {$trimmed_route} ends with 'me', skipping REST command registration.", 'rest' );
 				continue;
 			}
-			if ( 1 < count( $all_path_vars[0] ) ) {
-				WP_CLI::debug( "Route {$trimmed_route} has more than one path parameter. Will not function.", 'rest' );
-			}
 			if ( 0 < ( count( $all_path_vars[0] ) - count( $named_path_vars[0] ) ) ) {
 				WP_CLI::debug( "Route {$trimmed_route} has unnamed path variables, skipping REST command registration.", 'rest' );
 				continue;
@@ -163,6 +162,9 @@ class Runner {
 
 			// test if the route intends to operate on a single item or a collection
 			$is_singular = self::endsWith( end( $named_path_vars[0] ), $trimmed_route);
+
+			// save named path variables to later populate with values
+			$rest_command->set_named_path_vars( $named_path_vars );
 
 			// make named path variables required positional arguments
 			if ( count( $named_path_vars[1] ) && ! empty( $endpoint['args'] ) ) {

--- a/inc/Runner.php
+++ b/inc/Runner.php
@@ -143,6 +143,7 @@ class Runner {
 			$me_at_end = ( false !== stripos( $trimmed_route, '/me', strlen( $trimmed_route ) - 3 ) );
 			if ( $me_at_end ) {
 				// TODO code does not yet support understanding me as a required parameter of another route
+				WP_CLI::debug( "Route {$trimmed_route} ends with 'me', skipping REST command registration.", 'rest' );
 				continue;
 			}
 			$is_singular = ( $resource_id === substr( $trimmed_route, - strlen( $resource_id ) ) );
@@ -188,18 +189,14 @@ class Runner {
 		foreach( $supported_commands as $command => $endpoint_args ) {
 
 			$synopsis = array();
-			if ( in_array( $command, array( 'delete', 'get', 'update' ) ) ) {
-				$synopsis[] = array(
-					'name'        => 'id',
-					'type'        => 'positional',
-					'description' => 'The id for the resource.',
-					'optional'    => false,
-				);
-			}
-
 			foreach( $endpoint_args as $name => $args ) {
 				if ( ( 'id' === $name ) && in_array( $command, array( 'delete', 'get', 'update' ) ) ) {
-					// already above promoted it to a required positional argument
+					$synopsis[] = array(
+						'name'        => 'id',
+						'type'        => 'positional',
+						'description' => ! empty( $args['description'] ) ? $args['description'] : 'The id for the resource.',
+						'optional'    => false,
+					);
 					continue;
 				}
 				$arg_reg = array(

--- a/inc/Runner.php
+++ b/inc/Runner.php
@@ -89,8 +89,12 @@ class Runner {
 	 */
 	private static function auto_discover_api( $url ) {
 		$response = Utils\http_request( 'HEAD', $url );
-		if ( $response->status_code >= 400 ) return false;
-		if ( empty( $response->headers['link'] ) ) return false;
+		if ( $response->status_code >= 400 ) {
+			return false;
+		}
+		if ( empty( $response->headers['link'] ) ) {
+			return false;
+		}
 		$bits = explode( ';', $response->headers['link'] );
 		if ( 'rel="https://api.w.org/"' !== trim( $bits[1] ) ) {
 			return false;
@@ -112,8 +116,12 @@ class Runner {
 			$headers['Authorization'] = 'Basic ' . base64_encode( $auth['username'] . ':' . $auth['password'] );
 		}
 		$response = Utils\http_request( 'GET', $api_url, null, $headers );
-		if ( $response->status_code >= 400 ) return false;
-		if ( empty( $response->body ) ) return false;
+		if ( $response->status_code >= 400 ) {
+			return false;
+		}
+		if ( empty( $response->body ) ) {
+			return false;
+		}
 		return json_decode( $response->body, true );
 	}
 


### PR DESCRIPTION
**fix basic auth**
api index and therefore the routes wouldn't load because code didn't pass auth as needed at that stage

**fix lists**
when using the command "list" the code was not handling some lists being returned from WP 4.7.2. For example:
- wp-cli --http=https://user:password@server.domain.com rest settings list 
- wp-cli --http=https://user:password@server.domain.com rest status list

**error handling of outputs**
Added error handling of outputs. E.g., if an error occurs, then --porcelain does not output data.

Dev tested against WP 4.7.2 on Ubuntu 16.04 with PHP 7.0.13