### PR TITLE
Update RESTful WP-CLI for WordPress 4.7

### DIFF
--- a/features/comment.feature
+++ b/features/comment.feature
@@ -2,7 +2,6 @@ Feature: Manage WordPress comments through the REST API
 
   Background:
     Given a WP install
-    And I run `wp plugin install rest-api --activate`
 
   Scenario: Help for all available commands
     When I run `wp rest comment --help`
@@ -133,7 +132,7 @@ Feature: Manage WordPress comments through the REST API
     When I try `wp rest comment update 1 --content="Hello World"`
     Then STDERR should contain:
       """
-      Error: Sorry, you can not edit this comment
+      Error: Sorry, you are not allowed to edit this comment.
       """
 
     When I run `wp rest comment update 1 --content="Hello World" --user=1`
@@ -152,7 +151,7 @@ Feature: Manage WordPress comments through the REST API
     When I try `wp rest comment delete 1`
     Then STDERR should contain:
       """
-      Error: Sorry, you can not delete this comment
+      Error: Sorry, you are not allowed to delete this comment.
       """
 
     When I run `wp rest comment delete 1 --user=1`

--- a/features/load-rest.feature
+++ b/features/load-rest.feature
@@ -2,7 +2,6 @@ Feature: Manage WordPress through endpoints locally
 
   Background:
     Given a WP install
-    And I run `wp plugin install rest-api --activate`
 
   Scenario: REST endpoints should load as WP-CLI commands
     When I run `wp help rest`

--- a/features/post.feature
+++ b/features/post.feature
@@ -2,7 +2,6 @@ Feature: Manage WordPress posts through the REST API
 
   Background:
     Given a WP install
-    And I run `wp plugin install rest-api --activate`
 
   Scenario: Get the value of an individual post field
     When I run `wp rest post get 1 --field=title`

--- a/inc/RestCommand.php
+++ b/inc/RestCommand.php
@@ -110,13 +110,14 @@ class RestCommand {
 	 */
 	public function delete_item( $args, $assoc_args ) {
 		list( $status, $body ) = $this->do_request( 'DELETE', $this->get_filled_route( $args ), $assoc_args );
+		$id = isset( $body['previous'] ) ? $body['previous']['id'] : $body['id'];
 		if ( Utils\get_flag_value( $assoc_args, 'porcelain' ) ) {
-			WP_CLI::line( $body['id'] );
+			WP_CLI::line( $id );
 		} else {
 			if ( empty( $assoc_args['force'] ) ) {
-				WP_CLI::success( "Trashed {$this->name} {$body['id']}." );
+				WP_CLI::success( "Trashed {$this->name} {$id}." );
 			} else {
-				WP_CLI::success( "Deleted {$this->name} {$body['id']}." );
+				WP_CLI::success( "Deleted {$this->name} {$id}." );
 			}
 		}
 	}


### PR DESCRIPTION
* WP 4.7 returns two different bodies, depending if one was deleted
* Update tests for WordPress 4.7