### PR TITLE
Returns the endpoint url

### DIFF
--- a/inc/Runner.php
+++ b/inc/Runner.php
@@ -95,10 +95,10 @@ class Runner {
 		if ( empty( $response->headers['link'] ) ) {
 			return false;
 		}
-		if ( ! self::discover_wp_api( $response->headers['link'] ) ) {
+		if ( ! ( $endpoint = self::discover_wp_api( $response->headers['link'] ) ) ) {
 			return false;
 		}
-		return trim( $bits[0], '<>' );
+		return $endpoint;
 	}
 
 	private static function discover_wp_api( $link_headers ) {

--- a/inc/Runner.php
+++ b/inc/Runner.php
@@ -102,11 +102,14 @@ class Runner {
 	}
 
 	private static function discover_wp_api( $link_headers ) {
-		if ( false !== strpos( $link_headers, 'rel="https://api.w.org/"' ) ) {
-			return true;
-		} else {
-			return false;
+		$links = explode( ",", $link_headers );
+		foreach ( $links as $link ) {
+			if ( false !== strpos( $link, 'rel="https://api.w.org/"' ) ) {
+				$bits = explode( ";", trim( $link ) );
+				return trim( trim( $bits[0] ), '<>' );
+			}
 		}
+		return false;
 	}
 
 	/**

--- a/inc/Runner.php
+++ b/inc/Runner.php
@@ -102,12 +102,8 @@ class Runner {
 	}
 
 	private static function discover_wp_api( $link_headers ) {
-		$links = explode( ",", $link_headers );
-		foreach ( $links as $link ) {
-			if ( false !== strpos( $link, 'rel="https://api.w.org/"' ) ) {
-				$bits = explode( ";", trim( $link ) );
-				return trim( trim( $bits[0] ), '<>' );
-			}
+		if ( preg_match( '#<([^>]+)> *; *rel="https://api.w.org/"#', $link_headers, $matches ) ) {
+			return $matches[1];
 		}
 		return false;
 	}

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -14,20 +14,20 @@ class Runner_Test extends PHPUnit_Framework_TestCase {
 	public function test_single_link_header() {
 		$link_headers = '<https://example.com/wp-json/>; rel="https://api.w.org/"';
 		$res = $this->method->invokeArgs( null, array( $link_headers ) );
-		$this->assertTrue( $res );
+		$this->assertSame( "https://example.com/wp-json/", $res );
 	}
 
 
 	public function test_multiple_link_header() {
 		$link_headers = '<https://example.com/wp-json/>;rel="https://api.w.org/",<https://wp.me/8laBl>;rel=shortlink';
 		$res = $this->method->invokeArgs( null, array( $link_headers ) );
-		$this->assertTrue( $res );
+		$this->assertSame( "https://example.com/wp-json/", $res );
 	}
 
 	public function test_multiple_link_header_with_space() {
-		$link_headers = '<https://example.com/wp-json/>; rel="https://api.w.org/", <https://wp.me/8laBl>; rel=shortlink';
+		$link_headers = ' <https://example.com/wp-json/> ; rel="https://api.w.org/", <https://wp.me/8laBl>; rel=shortlink';
 		$res = $this->method->invokeArgs( null, array( $link_headers ) );
-		$this->assertTrue( $res );
+		$this->assertSame( "https://example.com/wp-json/", $res );
 	}
 
 	public function test_wp_api_not_found() {


### PR DESCRIPTION
`discover_wp_api()` must return endpoint URL when endpoint is found.
It is a bug of #109... 😓 