### PR TITLE
Support inclusion of additional fields which without schema

### DIFF
--- a/inc/RestCommand.php
+++ b/inc/RestCommand.php
@@ -482,8 +482,37 @@ EOT;
 				$fields[] = $key;
 			}
 		}
+
+		foreach( $this->get_additional_fields( $this->schema['title'] ) as $field_name => $field ) {
+			// For back-compat, include any field with an empty schema
+			// because it won't be present in $this->get_item_schema().
+			// @see \WP_REST_Controller::get_fields_for_response
+			if ( is_null( $field['schema'] ) ) {
+				$fields[] = $field_name;
+			}
+		}
 		return $fields;
 	}
+
+	/**
+	 * Retrieves all of the registered additional fields for a given object-type.
+	 * Here because the Rest Controller's method is protected.
+	 *
+	 * @param string $object_type
+	 *
+	 *@see \WP_REST_Controller::get_additional_fields
+	 *
+	 */
+	private function get_additional_fields( $object_type ) {
+		global $wp_rest_additional_fields;
+
+		if ( ! $wp_rest_additional_fields || ! isset( $wp_rest_additional_fields[ $object_type ] ) ) {
+			return array();
+		}
+
+		return $wp_rest_additional_fields[ $object_type ];
+	}
+
 
 	/**
 	 * Get the base route for this resource
@@ -558,7 +587,7 @@ EOT;
 
 			foreach( $dictated as $value ) {
 
-				if ( ! $current 
+				if ( ! $current
 					|| ! in_array( $value, $current ) ) {
 					$this->add_line( '- ' . $value );
 				}


### PR DESCRIPTION
Be default the `WP_REST_Controller::get_fields_for_response` allows additional fields which are registered without specifying a `schema`. It is noted with the following comment:

```php
// For back-compat, include any field with an empty schema
// because it won't be present in $this->get_item_schema().
```
This small change allows the response from this command to mimic the same behavior and return the same results as the api responses when this case is present.

