### PR TITLE
Fix PHP warning

### DIFF
--- a/inc/RestCommand.php
+++ b/inc/RestCommand.php
@@ -171,7 +171,7 @@ class RestCommand {
 
 		if ( ! empty( $assoc_args['fields'] ) ) {
 			foreach( $items as $key => $item ) {
-				$items[ $key ] = self::limit_item_to_fields( $item, $fields );
+				$items[ $key ] = self::limit_item_to_fields( $item, $assoc_args['fields'] );
 			}
 		}
 


### PR DESCRIPTION
Fixed https://github.com/wp-cli/restful/issues/139

* Fixes PHP warning